### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Add the following configuration to your project configuration `mix.exs`:
 
         def grisp do
             [
-                otp: [verson: "26"],
+                otp: [version: "27"],
                 deploy: [
                     # pre_script: "rm -rf /Volumes/GRISP/*",
                     # destination: "tmp/grisp"


### PR DESCRIPTION
otp: [verson: "26"], changed to otp: [version: "27"]

spelling verson produced a _matchstate term not allowed_ and stopped the VM.