### PR TITLE
Add mix grisp.configure support for GRiSP.io configuration

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # GRiSP Mix plug-in
 
-Mix plug-in to build and deploy GRiSP applications for the [GRiSP board][grisp].
+Mix plug-in to scaffold and deploy GRiSP applications for the [GRiSP board][grisp].
 
 ## Summary
 
-The package can be installed by adding `mix_grisp` to your list of dependencies
-in `mix.exs`:
+Add `mix_grisp` to your project dependencies:
 
 ```elixir
 def deps do
@@ -15,172 +14,164 @@ def deps do
 end
 ```
 
-## New Project Step-By-Step
+The plugin currently provides:
 
-### Create New Project
+- `mix grisp.configure`
+- `mix grisp.deploy`
 
-Create a project using Elixir default project template:
+Implementation notes:
 
-    ```
-    $ mix new testex --module TestEx
-    $ cd testex
-    ```
+- [CLI Flow](docs/cli_flow.md)
 
-### Add Dependencies
+## Recommended Flow
 
-Add the following dependencies in the project configuration `mix.exs`:
+The best approach today is:
 
-    ```
-        defp deps do
-            [
-                ...
-                {:grisp, "~> 2.4"},
-                {:mix_grisp, "~> 0.2.0", only: :dev},
-            ]
-        end
-    ```
+1. Start from a simple `mix new` project.
+2. Add `mix_grisp` to `deps/0`.
+3. Run `mix deps.get`.
+4. Run `mix grisp.configure` before heavily customizing `mix.exs` or `config/config.exs`.
+5. Review any printed manual steps after the command finishes.
 
-### Configure Grisp
+`mix grisp.configure` is intentionally conservative:
 
-Add the following configuration to your project configuration `mix.exs`:
+- it creates missing GRiSP files
+- it patches simple `mix new`-style `mix.exs` files automatically
+- it patches `config/config.exs` for GRiSP.io when possible
+- if the file shape is not safe to rewrite, it prints exact manual steps instead
 
-    ```
-        def project do
-            [
-                ...
-                grisp: grisp(),
-                releases: releases()
-            ]
-        end
+## Configure
 
-        def grisp do
-            [
-                otp: [version: "27"],
-                deploy: [
-                    # pre_script: "rm -rf /Volumes/GRISP/*",
-                    # destination: "tmp/grisp"
-                    # post_script: "diskutil unmount /Volumes/GRISP",
-                ]
-            ]
-        end
+Run the interactive flow:
 
-        def releases do
-            [
-                {:myapp,
-                    [
-                        overwrite: true,
-                        cookie: "grisp",
-                        include_erts: &MixGrisp.Release.erts/0,
-                        steps: [&MixGrisp.Release.init/1, :assemble],
-                        include_executables_for: [],
-                        strip_beams: Mix.env() == :prod
-                    ]}
-                ]
-        end
-    ```
+```sh
+mix grisp.configure
+```
 
-You can uncomment the lines in the `deploy` list after setting the proper mount
-point for your SD card if you want to deploy directly to it. The destination can be
-a normal path if you want to deploy to a local directory.
+Or run it non-interactively with flags:
 
-Add the following boot configuration files after changing `GRISP_HOSTNAME` to
-the hostname you want the grisp board to have, `WLAN_SSID` and `WLAN_PASSWORD`
-to the ssid and password of the WiFi network the Grisp board should connect to.
+```sh
+mix grisp.configure --interactive false --name demo --network true --network-type wifi
+```
 
-    * `grisp/grisp2/common/deploy/files/grisp.ini.mustache`
+### Important Flags
 
-        ```
-        [erlang]
-        args = erl.rtems -C multi_time_warp -- -mode embedded -home . -pa . -root {{release_name}} -bindir {{release_name}}/erts-{{erts_vsn}}/bin -boot {{release_name}}/releases/{{release_version}}/start -boot_var RELEASE_LIB {{release_name}}/lib  -config {{release_name}}/releases/{{release_version}}/sys.config -s elixir start_iex -extra --no-halt
-        shell = none
+- `--interactive true|false`
+- `--name <otp_app>`
+- `--otp-version <version>`
+- `--network true|false`
+- `--network-type ethernet|wifi`
+- `--ssid <ssid>`
+- `--psk <psk>`
+- `--grisp-io true|false`
+- `--grisp-io-linking true|false`
+- `--token <linking_token>`
+- `--epmd true|false`
+- `--node-name <short_name>`
+- `--cookie <cookie>`
 
-        [network]
-        ip_self=dhcp
-        wlan=enable
-        hostname=GRISP_HOSTNAME
-        wpa=wpa_supplicant.conf
-        ```
+### What It Generates
 
+Depending on the selected options, `mix grisp.configure` creates:
 
-    * `grisp/grisp2/common/deploy/files/wpa_supplicant.conf`
+- `config/config.exs` if it does not already exist
+- `grisp/grisp2/common/deploy/files/grisp.ini.mustache`
+- `grisp/grisp2/common/deploy/files/wpa_supplicant.conf` for Wi-Fi
+- `grisp/grisp2/common/deploy/files/erl_inetrc` when GRiSP.io is not enabled
 
-        ```
-        network={
-            ssid="WLAN_SSID"
-            key_mgmt=WPA-PSK
-            psk="WLAN_PASSWORD"
-        }
-        ```
+The base `grisp.ini.mustache` is kept canonical and then refined during rendering:
 
-### Add Configuration
+- Wi-Fi adds `wpa=wpa_supplicant.conf`
+- `epmd` adds:
+  - `-kernel inetrc "./erl_inetrc"`
+  - `-internal_epmd epmd_sup`
+  - `-sname <node_name>`
+  - `-setcookie <cookie>`
 
-If not generated bu Mix template, add the file `config/config.exs`:
+### What It Patches Automatically
 
-    ```
-    import Config
-    ```
+For simple `mix new`-style projects, the plugin can patch `mix.exs` to add:
 
-### Check OTP Version
+- `grisp: grisp()`
+- `releases: releases()`
+- `{:grisp, "~> 2.4"}`
+- `{:epmd, git: "https://github.com/erlang/epmd", ref: "4d1a59", runtime: false}` when `epmd` is enabled
+- `def grisp do`
+- `def releases do`
+- `included_applications: [:epmd]` in `application/0` when `epmd` is enabled
 
-Verify that your default erlang version matches the one configured
-(26 in the example).
+For GRiSP.io, the plugin can patch `config/config.exs` to add:
 
-This is required because the beam files are compiled locally and need to be
-compiled by the same version of the VM.
+- `:grisp_keychain`
+- `:grisp_cryptoauth`
+- `:grisp_connect`
+- `:grisp_updater`
 
-### Get Dependencies
+If linking is enabled, the linking token is added to `config :grisp_connect`.
 
-Get all the dependencies:
+### What Still Requires Review
 
-    ```
-    $ mix deps.get
-    ```
+The plugin may still print manual steps. This is expected when:
 
-### Deploy The Project
+- `mix.exs` does not match a simple patchable shape
+- GRiSP.io dependencies need to be added with versions that match your GRiSP stack
+- additional app/runtime choices need review
 
-To deploy, use the grisp command provided by `mix_grisp`:
+In particular, GRiSP.io dependency versions are not auto-selected by the plugin.
+You should choose versions that match your target GRiSP setup.
 
-    ```
-    $ mix grisp.deploy
-    ```
+## Example Commands
 
-### Troubleshooting
+Wi-Fi project:
 
-#### This BEAM file was compiled for a later version of the run-time system
+```sh
+mix grisp.configure \
+  --interactive false \
+  --name demo \
+  --network true \
+  --network-type wifi \
+  --ssid mywifi \
+  --psk supersecret
+```
 
-Some bema files were compiled with a newer version of OTP, delete `_build` and
-`deps`, get the fresh dependencies (`mix deps.get`), and redeploy
-(`mix grisp.deploy`).
+Ethernet + Erlang distribution:
+
+```sh
+mix grisp.configure \
+  --interactive false \
+  --name demo \
+  --network true \
+  --network-type ethernet \
+  --epmd true \
+  --node-name mynode \
+  --cookie mycookie
+```
+
+GRiSP.io with device linking:
+
+```sh
+mix grisp.configure \
+  --interactive false \
+  --name demo \
+  --network true \
+  --network-type wifi \
+  --grisp-io true \
+  --grisp-io-linking true \
+  --token link-token
+```
+
+## Deploy
+
+After configuration and dependency setup, deploy with:
+
+```sh
+mix grisp.deploy
+```
+
+## Notes
+
+- Use the same OTP version locally that you target in the generated GRiSP configuration.
+- If you compiled dependencies with the wrong OTP version, remove `_build` and `deps`, run `mix deps.get`, and build again.
+- Read the GRiSP networking chapter in the wiki for board-specific runtime details.
 
 [grisp]: https://www.grisp.org
-
-
-## Enabling Erlang Distribution
-
-
-1. Add the erlang epmd to your release to be able to run Erlang distribution on GRiSP
-
-   1. Add the following line in your deps, this will ship epmd without starting it at boot.
-
-      ```elixir
-      {:epmd, git: "https://github.com/erlang/epmd", ref: "4d1a59", runtime: false},
-      ```
-
-   2. Add epmd to the included applications so its modules are loaded at runtime
-  
-      ```elixir
-       def application do
-        [
-          extra_applications: [:logger],
-          included_applications: [:epmd]
-        ]
-      end
-      ```
-
-2. Read the GRiSP.ini chapter of the [wiki](https://github.com/grisp/grisp/wiki/Connecting-over-WiFI-and-Ethernet#grisp-ini)
-
-3. Your grisp.ini.mustache file `args` should terminate with the following flags, choose a nodename and cookie of your liking.
-    ```
-    ... -s elixir start_iex -kernel inetrc "./erl_inetrc" -internal_epmd epmd_sup -sname mynode -setcookie mycookie -extra --no-halt
-    ```
-

--- a/docs/cli_flow.md
+++ b/docs/cli_flow.md
@@ -1,0 +1,116 @@
+# Current CLI Flow
+
+This document describes the current `mix grisp.configure` flow as implemented in
+`mix_grisp`.
+
+## Main Flow
+
+```mermaid
+flowchart TD
+    A["mix grisp.configure"] --> B["OptionParser.parse/2"]
+    B --> C["MixGrisp.Configure.run/2"]
+    C --> D["merge defaults + CLI opts"]
+    D --> E["normalize booleans + strings"]
+    E --> F{"interactive?"}
+
+    F -->|yes| G["Prompter.maybe_prompt/2"]
+    F -->|no| H["default network_type = ethernet when network=true"]
+
+    G --> I["Validator.validate!/1"]
+    H --> I["Validator.validate!/1"]
+
+    I --> J["TemplatePlan.build/1"]
+    J --> K["Renderer.apply/3"]
+    I --> L["MixExsPatcher.apply/2"]
+    I --> M["ConfigPatcher.apply/2"]
+
+    K --> N["created / skipped files"]
+    L --> O["mix.exs updated or manual steps"]
+    M --> P["config/config.exs updated or manual steps"]
+
+    N --> Q["task prints results"]
+    O --> Q
+    P --> Q
+```
+
+## Interactive Branch
+
+```mermaid
+flowchart TD
+    A["Prompter.maybe_prompt/2"] --> B["name"]
+    B --> C["network?"]
+    C -->|true| D["network_type: ethernet or wifi"]
+    C -->|false| E["skip network-specific prompts"]
+    D -->|wifi| F["ssid"]
+    F --> G["psk"]
+    D -->|ethernet| H["skip wifi details"]
+    G --> I["grisp_io?"]
+    H --> I["grisp_io?"]
+    E --> I["grisp_io?"]
+    I -->|true| J["grisp_io_linking?"]
+    J -->|true| K["token"]
+    J -->|false| L["continue"]
+    K --> L
+    I -->|false| L
+    L --> M["epmd?"]
+    M -->|true| N["node_name"]
+    N --> O["cookie"]
+    M -->|false| P["done"]
+    O --> P
+```
+
+## Generated Files
+
+```mermaid
+flowchart TD
+    A["validated config"] --> B{"network?"}
+    A --> C["config/config.exs"]
+
+    B -->|true| D["grisp.ini.mustache"]
+    B -->|false| E["no network files"]
+
+    D --> F{"network_type == wifi?"}
+    F -->|yes| G["wpa_supplicant.conf"]
+    F -->|no| H["no wpa_supplicant.conf"]
+
+    D --> I{"grisp_io?"}
+    I -->|false| J["erl_inetrc"]
+    I -->|true| K["no erl_inetrc"]
+```
+
+## Patchers
+
+```mermaid
+flowchart LR
+    A["validated config"] --> B["MixExsPatcher"]
+    A --> C["ConfigPatcher"]
+
+    B --> D["project/0"]
+    B --> E["deps/0"]
+    B --> F["application/0"]
+    B --> G["grisp/0 + releases/0 helpers"]
+
+    C --> H["append GRiSP.io runtime config"]
+    C --> I["device_linking_token when linking"]
+```
+
+## Module Map
+
+- [`lib/mix/tasks/grisp/configure.ex`](../lib/mix/tasks/grisp/configure.ex)
+  CLI entrypoint and result printing
+- [`lib/mix_grisp/configure.ex`](../lib/mix_grisp/configure.ex)
+  orchestration
+- [`lib/mix_grisp/configure/prompter.ex`](../lib/mix_grisp/configure/prompter.ex)
+  interactive prompts
+- [`lib/mix_grisp/configure/validator.ex`](../lib/mix_grisp/configure/validator.ex)
+  config validation
+- [`lib/mix_grisp/configure/template_plan.ex`](../lib/mix_grisp/configure/template_plan.ex)
+  file selection
+- [`lib/mix_grisp/configure/renderer.ex`](../lib/mix_grisp/configure/renderer.ex)
+  file rendering/copying
+- [`lib/mix_grisp/configure/mix_exs_patcher.ex`](../lib/mix_grisp/configure/mix_exs_patcher.ex)
+  conservative `mix.exs` patching
+- [`lib/mix_grisp/configure/config_patcher.ex`](../lib/mix_grisp/configure/config_patcher.ex)
+  conservative `config/config.exs` patching
+- [`lib/mix_grisp/configure/snippets.ex`](../lib/mix_grisp/configure/snippets.ex)
+  shared snippets and manual-step text

--- a/lib/mix/tasks/grisp/configure.ex
+++ b/lib/mix/tasks/grisp/configure.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Grisp.Configure do
     otp_version: :string,
     destination: :string,
     network: :string,
-    wifi: :string,
+    network_type: :string,
     ssid: :string,
     psk: :string,
     grisp_io: :string,

--- a/lib/mix/tasks/grisp/configure.ex
+++ b/lib/mix/tasks/grisp/configure.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.Grisp.Configure do
     grisp_io_linking: :string,
     token: :string,
     epmd: :string,
+    node_name: :string,
     cookie: :string
   ]
 
@@ -31,7 +32,7 @@ defmodule Mix.Tasks.Grisp.Configure do
     # If interactive mode grows, this task may need a friendlier error boundary.
     fail_on_invalid!(invalid)
 
-    %{result: result} = Configure.run(opts)
+    %{result: result, patch_result: patch_result} = Configure.run(opts)
 
     Enum.each(Enum.reverse(result.created), fn path ->
       Mix.shell().info("Created #{path}")
@@ -40,6 +41,8 @@ defmodule Mix.Tasks.Grisp.Configure do
     Enum.each(Enum.reverse(result.skipped), fn path ->
       Mix.shell().info("Skipped #{path}")
     end)
+
+    print_patch_result(patch_result)
   end
 
   defp fail_on_invalid!([]), do: :ok
@@ -55,4 +58,28 @@ defmodule Mix.Tasks.Grisp.Configure do
   defp format_invalid_option({<<"--", option::binary>>, value}), do: format_invalid_option({option, value})
   defp format_invalid_option({option, nil}), do: "--#{option}"
   defp format_invalid_option({option, value}), do: "--#{option}=#{value}"
+
+  defp print_patch_result(%{status: :updated, updated: paths, manual: manual}) do
+    Enum.each(paths, fn path ->
+      Mix.shell().info("Updated #{path}")
+    end)
+
+    Enum.each(manual, fn step ->
+      Mix.shell().info("Manual step:\n#{step}")
+    end)
+  end
+
+  defp print_patch_result(%{status: :unchanged, manual: manual}) do
+    Enum.each(manual, fn step ->
+      Mix.shell().info("Manual step:\n#{step}")
+    end)
+  end
+
+  defp print_patch_result(%{status: :manual, manual: manual}) do
+    Mix.shell().info("Could not safely update mix.exs automatically.")
+
+    Enum.each(manual, fn step ->
+      Mix.shell().info("Manual step:\n#{step}")
+    end)
+  end
 end

--- a/lib/mix/tasks/grisp/configure.ex
+++ b/lib/mix/tasks/grisp/configure.ex
@@ -1,0 +1,58 @@
+defmodule Mix.Tasks.Grisp.Configure do
+  @moduledoc """
+  Scaffolds GRiSP configuration files for a Mix project.
+  """
+
+  use Mix.Task
+
+  alias MixGrisp.Configure
+
+  @shortdoc "Scaffolds GRiSP configuration files"
+
+  @switches [
+    interactive: :string,
+    name: :string,
+    otp_version: :string,
+    destination: :string,
+    network: :string,
+    wifi: :string,
+    ssid: :string,
+    psk: :string,
+    grisp_io: :string,
+    grisp_io_linking: :string,
+    token: :string,
+    epmd: :string,
+    cookie: :string
+  ]
+
+  def run(args) do
+    {opts, _argv, invalid} = OptionParser.parse(args, strict: @switches)
+    # For now CLI errors bubble up as Mix exceptions from the workflow layers.
+    # If interactive mode grows, this task may need a friendlier error boundary.
+    fail_on_invalid!(invalid)
+
+    %{result: result} = Configure.run(opts)
+
+    Enum.each(Enum.reverse(result.created), fn path ->
+      Mix.shell().info("Created #{path}")
+    end)
+
+    Enum.each(Enum.reverse(result.skipped), fn path ->
+      Mix.shell().info("Skipped #{path}")
+    end)
+  end
+
+  defp fail_on_invalid!([]), do: :ok
+
+  defp fail_on_invalid!(invalid) do
+    formatted =
+      invalid
+      |> Enum.map_join(", ", &format_invalid_option/1)
+
+    Mix.raise("Invalid options: #{formatted}")
+  end
+
+  defp format_invalid_option({<<"--", option::binary>>, value}), do: format_invalid_option({option, value})
+  defp format_invalid_option({option, nil}), do: "--#{option}"
+  defp format_invalid_option({option, value}), do: "--#{option}=#{value}"
+end

--- a/lib/mix/tasks/grisp/configure.ex
+++ b/lib/mix/tasks/grisp/configure.ex
@@ -32,7 +32,8 @@ defmodule Mix.Tasks.Grisp.Configure do
     # If interactive mode grows, this task may need a friendlier error boundary.
     fail_on_invalid!(invalid)
 
-    %{result: result, patch_result: patch_result} = Configure.run(opts)
+    %{result: result, patch_result: patch_result, config_patch_result: config_patch_result} =
+      Configure.run(opts)
 
     Enum.each(Enum.reverse(result.created), fn path ->
       Mix.shell().info("Created #{path}")
@@ -43,6 +44,7 @@ defmodule Mix.Tasks.Grisp.Configure do
     end)
 
     print_patch_result(patch_result)
+    print_config_patch_result(config_patch_result)
   end
 
   defp fail_on_invalid!([]), do: :ok
@@ -77,6 +79,30 @@ defmodule Mix.Tasks.Grisp.Configure do
 
   defp print_patch_result(%{status: :manual, manual: manual}) do
     Mix.shell().info("Could not safely update mix.exs automatically.")
+
+    Enum.each(manual, fn step ->
+      Mix.shell().info("Manual step:\n#{step}")
+    end)
+  end
+
+  defp print_config_patch_result(%{status: :updated, updated: paths, manual: manual}) do
+    Enum.each(paths, fn path ->
+      Mix.shell().info("Updated #{path}")
+    end)
+
+    Enum.each(manual, fn step ->
+      Mix.shell().info("Manual step:\n#{step}")
+    end)
+  end
+
+  defp print_config_patch_result(%{status: :unchanged, manual: manual}) do
+    Enum.each(manual, fn step ->
+      Mix.shell().info("Manual step:\n#{step}")
+    end)
+  end
+
+  defp print_config_patch_result(%{status: :manual, manual: manual}) do
+    Mix.shell().info("Could not safely update config/config.exs automatically.")
 
     Enum.each(manual, fn step ->
       Mix.shell().info("Manual step:\n#{step}")

--- a/lib/mix_grisp/configure.ex
+++ b/lib/mix_grisp/configure.ex
@@ -1,6 +1,7 @@
 defmodule MixGrisp.Configure do
   @moduledoc false
 
+  alias MixGrisp.Configure.MixExsPatcher
   alias MixGrisp.Configure.Prompter
   alias MixGrisp.Configure.Renderer
   alias MixGrisp.Configure.TemplatePlan
@@ -21,6 +22,7 @@ defmodule MixGrisp.Configure do
     grisp_io_linking: false,
     token: nil,
     epmd: false,
+    node_name: nil,
     cookie: nil
   }
 
@@ -53,8 +55,9 @@ defmodule MixGrisp.Configure do
 
     plan = TemplatePlan.build(config)
     result = Renderer.apply(plan, config, run_opts)
+    patch_result = MixExsPatcher.apply(config, run_opts)
 
-    %{config: config, plan: plan, result: result}
+    %{config: config, plan: plan, result: result, patch_result: patch_result}
   end
 
   defp normalize_booleans(config) do

--- a/lib/mix_grisp/configure.ex
+++ b/lib/mix_grisp/configure.ex
@@ -1,6 +1,7 @@
 defmodule MixGrisp.Configure do
   @moduledoc false
 
+  alias MixGrisp.Configure.ConfigPatcher
   alias MixGrisp.Configure.MixExsPatcher
   alias MixGrisp.Configure.Prompter
   alias MixGrisp.Configure.Renderer
@@ -56,8 +57,15 @@ defmodule MixGrisp.Configure do
     plan = TemplatePlan.build(config)
     result = Renderer.apply(plan, config, run_opts)
     patch_result = MixExsPatcher.apply(config, run_opts)
+    config_patch_result = ConfigPatcher.apply(config, run_opts)
 
-    %{config: config, plan: plan, result: result, patch_result: patch_result}
+    %{
+      config: config,
+      plan: plan,
+      result: result,
+      patch_result: patch_result,
+      config_patch_result: config_patch_result
+    }
   end
 
   defp normalize_booleans(config) do

--- a/lib/mix_grisp/configure.ex
+++ b/lib/mix_grisp/configure.ex
@@ -1,7 +1,11 @@
 defmodule MixGrisp.Configure do
   @moduledoc false
 
+  alias MixGrisp.Configure.Renderer
+  alias MixGrisp.Configure.TemplatePlan
   alias MixGrisp.Configure.Validator
+
+  @boolean_keys [:interactive, :network, :wifi, :grisp_io, :grisp_io_linking, :epmd]
 
   @defaults %{
     interactive: true,
@@ -26,8 +30,44 @@ defmodule MixGrisp.Configure do
   def merge_cli(opts) when is_list(opts) do
     opts
     |> Enum.into(%{})
-    # TODO: Item 2: reject unknown configure keys once the task/parser boundary is in place.
+    # TODO: Reject unknown configure keys once the task/parser boundary is finalized.
+    # This module currently accepts CLI-shaped input and normalizes it before running
+    # the workflow; if we later call it with already-normalized state, split those paths.
     |> then(&Map.merge(defaults(), &1))
+    |> normalize_booleans()
     |> Validator.normalize()
+  end
+
+  def run(opts, run_opts \\ []) when is_list(opts) and is_list(run_opts) do
+    config =
+      opts
+      |> merge_cli()
+      |> ensure_non_interactive!()
+      |> Validator.validate!()
+
+    plan = TemplatePlan.build(config)
+    result = Renderer.apply(plan, config, run_opts)
+
+    %{config: config, plan: plan, result: result}
+  end
+
+  defp ensure_non_interactive!(%{interactive: false} = config), do: config
+
+  defp ensure_non_interactive!(_config) do
+    Mix.raise("Interactive mode is not implemented yet. Use --interactive false.")
+  end
+
+  defp normalize_booleans(config) do
+    Enum.reduce(@boolean_keys, config, fn key, acc ->
+      Map.update!(acc, key, &normalize_boolean/1)
+    end)
+  end
+
+  defp normalize_boolean(value) when value in [true, false], do: value
+  defp normalize_boolean("true"), do: true
+  defp normalize_boolean("false"), do: false
+
+  defp normalize_boolean(value) do
+    Mix.raise("Invalid boolean value: #{inspect(value)}")
   end
 end

--- a/lib/mix_grisp/configure.ex
+++ b/lib/mix_grisp/configure.ex
@@ -1,11 +1,12 @@
 defmodule MixGrisp.Configure do
   @moduledoc false
 
+  alias MixGrisp.Configure.Prompter
   alias MixGrisp.Configure.Renderer
   alias MixGrisp.Configure.TemplatePlan
   alias MixGrisp.Configure.Validator
 
-  @boolean_keys [:interactive, :network, :wifi, :grisp_io, :grisp_io_linking, :epmd]
+  @boolean_keys [:interactive, :network, :grisp_io, :grisp_io_linking, :epmd]
 
   @defaults %{
     interactive: true,
@@ -13,7 +14,7 @@ defmodule MixGrisp.Configure do
     otp_version: "27",
     destination: nil,
     network: false,
-    wifi: false,
+    network_type: nil,
     ssid: nil,
     psk: nil,
     grisp_io: false,
@@ -39,22 +40,21 @@ defmodule MixGrisp.Configure do
   end
 
   def run(opts, run_opts \\ []) when is_list(opts) and is_list(run_opts) do
+    config = merge_cli(opts)
+
     config =
-      opts
-      |> merge_cli()
-      |> ensure_non_interactive!()
-      |> Validator.validate!()
+      if config.interactive do
+        Prompter.maybe_prompt(config, run_opts)
+      else
+        default_network_type(config)
+      end
+
+    config = Validator.validate!(config)
 
     plan = TemplatePlan.build(config)
     result = Renderer.apply(plan, config, run_opts)
 
     %{config: config, plan: plan, result: result}
-  end
-
-  defp ensure_non_interactive!(%{interactive: false} = config), do: config
-
-  defp ensure_non_interactive!(_config) do
-    Mix.raise("Interactive mode is not implemented yet. Use --interactive false.")
   end
 
   defp normalize_booleans(config) do
@@ -70,4 +70,10 @@ defmodule MixGrisp.Configure do
   defp normalize_boolean(value) do
     Mix.raise("Invalid boolean value: #{inspect(value)}")
   end
+
+  defp default_network_type(%{network: true, network_type: nil} = config) do
+    %{config | network_type: "ethernet"}
+  end
+
+  defp default_network_type(config), do: config
 end

--- a/lib/mix_grisp/configure.ex
+++ b/lib/mix_grisp/configure.ex
@@ -1,0 +1,33 @@
+defmodule MixGrisp.Configure do
+  @moduledoc false
+
+  alias MixGrisp.Configure.Validator
+
+  @defaults %{
+    interactive: true,
+    name: nil,
+    otp_version: "27",
+    destination: nil,
+    network: false,
+    wifi: false,
+    ssid: nil,
+    psk: nil,
+    grisp_io: false,
+    grisp_io_linking: false,
+    token: nil,
+    epmd: false,
+    cookie: nil
+  }
+
+  def defaults do
+    @defaults
+  end
+
+  def merge_cli(opts) when is_list(opts) do
+    opts
+    |> Enum.into(%{})
+    # TODO: Item 2: reject unknown configure keys once the task/parser boundary is in place.
+    |> then(&Map.merge(defaults(), &1))
+    |> Validator.normalize()
+  end
+end

--- a/lib/mix_grisp/configure/config_patcher.ex
+++ b/lib/mix_grisp/configure/config_patcher.ex
@@ -1,0 +1,48 @@
+defmodule MixGrisp.Configure.ConfigPatcher do
+  @moduledoc false
+
+  alias MixGrisp.Configure.Snippets
+
+  def apply(config, opts \\ []) when is_map(config) and is_list(opts) do
+    root = Keyword.get(opts, :root, File.cwd!())
+    path = Path.join(root, "config/config.exs")
+
+    cond do
+      not config.grisp_io ->
+        %{status: :unchanged, updated: [], manual: []}
+
+      not File.exists?(path) ->
+        %{status: :manual, updated: [], manual: manual_steps(config)}
+
+      true ->
+        contents = File.read!(path)
+        patched = patch_config(contents, config)
+
+        if patched == contents do
+          %{status: :unchanged, updated: [], manual: manual_steps(config)}
+        else
+          File.write!(path, patched)
+          %{status: :updated, updated: ["config/config.exs"], manual: manual_steps(config)}
+        end
+    end
+  end
+
+  defp patch_config(contents, config) do
+    # TODO: Make this patching more granular. Right now any existing
+    # `config :grisp_connect` block is treated as "already configured", which can
+    # skip adding other missing GRiSP.io sections such as :grisp_keychain,
+    # :grisp_cryptoauth, or :grisp_updater.
+    if String.contains?(contents, "config :grisp_connect") do
+      contents
+    else
+      String.trim_trailing(contents) <> "\n\n" <> Snippets.grisp_io_config(config)
+    end
+  end
+
+  defp manual_steps(config) do
+    [
+      Snippets.grisp_io_dependencies_manual_step(),
+      Snippets.grisp_io_config_manual_step(config)
+    ]
+  end
+end

--- a/lib/mix_grisp/configure/mix_exs_patcher.ex
+++ b/lib/mix_grisp/configure/mix_exs_patcher.ex
@@ -1,0 +1,215 @@
+defmodule MixGrisp.Configure.MixExsPatcher do
+  @moduledoc false
+
+  @project_regex ~r/def project(?:\(\))? do\s*\[(?<body>.*?)\]/ms
+  @deps_regex ~r/defp deps(?:\(\))? do\s*\[(?<body>.*?)\]/ms
+  @application_regex ~r/def application(?:\(\))? do\s*\[(?<body>.*?)\]/ms
+
+  def apply(config, opts \\ []) when is_map(config) and is_list(opts) do
+    root = Keyword.get(opts, :root, File.cwd!())
+    mix_exs_path = Path.join(root, "mix.exs")
+
+    case File.read(mix_exs_path) do
+      {:ok, contents} ->
+        patch(mix_exs_path, contents, config)
+
+      {:error, :enoent} ->
+        %{status: :manual, updated: [], manual: manual_steps(config)}
+    end
+  end
+
+  defp patch(path, contents, config) do
+    with {:ok, project_patched} <- patch_project(contents),
+         {:ok, deps_patched} <- patch_deps(project_patched, config),
+         {:ok, application_patched} <- patch_application(deps_patched, config),
+         {:ok, module_patched} <- patch_module_helpers(application_patched, config),
+         true <- module_patched != contents do
+      File.write!(path, module_patched)
+      %{status: :updated, updated: ["mix.exs"], manual: remaining_manual_steps(config)}
+    else
+      false ->
+        %{status: :unchanged, updated: [], manual: remaining_manual_steps(config)}
+
+      {:error, :unsupported} ->
+        %{status: :manual, updated: [], manual: manual_steps(config)}
+    end
+  end
+
+  defp patch_project(contents) do
+    case Regex.named_captures(@project_regex, contents) do
+      %{"body" => body} ->
+        body =
+          body
+          |> ensure_project_entry("grisp: grisp()")
+          |> ensure_project_entry("releases: releases()")
+
+        {:ok, Regex.replace(@project_regex, contents, "def project do\n    [\n#{body}\n    ]", global: false)}
+
+      _ ->
+        {:error, :unsupported}
+    end
+  end
+
+  defp patch_deps(contents, config) do
+    case Regex.named_captures(@deps_regex, contents) do
+      %{"body" => body} ->
+        body =
+          body
+          |> ensure_dep(~s({:grisp, "~> 2.4"}))
+          |> maybe_ensure_epmd_dep(config)
+
+        {:ok, Regex.replace(@deps_regex, contents, "defp deps do\n    [\n#{body}\n    ]", global: false)}
+
+      _ ->
+        {:error, :unsupported}
+    end
+  end
+
+  defp patch_module_helpers(contents, config) do
+    contents =
+      contents
+      |> ensure_helper("grisp", grisp_snippet(config))
+      |> ensure_helper("releases", releases_snippet(config))
+
+    {:ok, contents}
+  end
+
+  defp patch_application(contents, %{epmd: true}) do
+    case Regex.named_captures(@application_regex, contents) do
+      %{"body" => body} ->
+        body =
+          body
+          |> ensure_application_entry("extra_applications: [:logger]")
+          |> ensure_application_entry("included_applications: [:epmd]")
+
+        {:ok, Regex.replace(@application_regex, contents, "def application do\n    [\n#{body}\n    ]", global: false)}
+
+      _ ->
+        {:error, :unsupported}
+    end
+  end
+
+  defp patch_application(contents, _config), do: {:ok, contents}
+
+  defp ensure_project_entry(body, entry) do
+    if String.contains?(body, entry), do: body, else: append_list_line(body, entry)
+  end
+
+  defp ensure_dep(body, dep) do
+    if String.contains?(body, dep), do: body, else: append_list_line(body, dep)
+  end
+
+  defp ensure_application_entry(body, entry) do
+    if String.contains?(body, entry), do: body, else: append_list_line(body, entry)
+  end
+
+  defp maybe_ensure_epmd_dep(body, %{epmd: true}) do
+    ensure_dep(body, ~s({:epmd, git: "https://github.com/erlang/epmd", ref: "4d1a59", runtime: false}))
+  end
+
+  defp maybe_ensure_epmd_dep(body, _config), do: body
+
+  defp append_list_line(body, line) do
+    trimmed = String.trim_trailing(body)
+
+    cond do
+      trimmed == "" ->
+        "      #{line}"
+
+      String.ends_with?(trimmed, ",") ->
+        trimmed <> "\n      #{line}"
+
+      true ->
+        trimmed <> ",\n      #{line}"
+    end
+  end
+
+  defp ensure_helper(contents, helper_name, snippet) do
+    if String.contains?(contents, "def #{helper_name} do") do
+      contents
+    else
+      contents
+      |> String.trim_trailing()
+      |> String.replace_suffix("end", "\n\n#{snippet}\nend")
+      |> Kernel.<>("\n")
+    end
+  end
+
+  defp grisp_snippet(config) do
+    """
+      def grisp do
+        [
+          otp: [version: "#{config.otp_version}"],
+          deploy: [
+            # pre_script: "rm -rf /Volumes/GRISP/*",
+            # destination: "tmp/grisp"
+            # post_script: "diskutil unmount /Volumes/GRISP",
+          ]
+        ]
+      end
+    """
+  end
+
+  defp releases_snippet(config) do
+    """
+      def releases do
+        [
+          {:#{config.name},
+            [
+              overwrite: true,
+              cookie: "#{config.cookie || "grisp"}",
+              include_erts: &MixGrisp.Release.erts/0,
+              steps: [&MixGrisp.Release.init/1, :assemble],
+              include_executables_for: [],
+              strip_beams: Mix.env() == :prod
+            ]}
+        ]
+      end
+    """
+  end
+
+  defp manual_steps(config) do
+    steps = [
+      """
+      Add to project/0:
+        grisp: grisp(),
+        releases: releases()
+      """,
+      """
+      Add to deps/0:
+        {:grisp, "~> 2.4"}
+      """,
+      grisp_snippet(config),
+      releases_snippet(config)
+    ]
+
+    if config.epmd do
+      steps ++
+        [
+          """
+          Add to deps/0:
+            {:epmd, git: "https://github.com/erlang/epmd", ref: "4d1a59", runtime: false}
+          """,
+          """
+          Add epmd to your application config so its modules are available at runtime:
+            extra_applications: [:logger]
+            included_applications: [:epmd]
+          """
+        ]
+    else
+      steps
+    end
+  end
+
+  defp remaining_manual_steps(%{epmd: true}) do
+    [
+      """
+      Add epmd to your application config so its modules are available at runtime:
+        extra_applications: [:logger]
+        included_applications: [:epmd]
+      """
+    ]
+  end
+
+  defp remaining_manual_steps(_config), do: []
+end

--- a/lib/mix_grisp/configure/mix_exs_patcher.ex
+++ b/lib/mix_grisp/configure/mix_exs_patcher.ex
@@ -1,6 +1,8 @@
 defmodule MixGrisp.Configure.MixExsPatcher do
   @moduledoc false
 
+  alias MixGrisp.Configure.Snippets
+
   @project_regex ~r/def project(?:\(\))? do\s*\[(?<body>.*?)\]/ms
   @deps_regex ~r/defp deps(?:\(\))? do\s*\[(?<body>.*?)\]/ms
   @application_regex ~r/def application(?:\(\))? do\s*\[(?<body>.*?)\]/ms
@@ -104,7 +106,7 @@ defmodule MixGrisp.Configure.MixExsPatcher do
   end
 
   defp maybe_ensure_epmd_dep(body, %{epmd: true}) do
-    ensure_dep(body, ~s({:epmd, git: "https://github.com/erlang/epmd", ref: "4d1a59", runtime: false}))
+    ensure_dep(body, Snippets.epmd_dependency())
   end
 
   defp maybe_ensure_epmd_dep(body, _config), do: body
@@ -135,38 +137,9 @@ defmodule MixGrisp.Configure.MixExsPatcher do
     end
   end
 
-  defp grisp_snippet(config) do
-    """
-      def grisp do
-        [
-          otp: [version: "#{config.otp_version}"],
-          deploy: [
-            # pre_script: "rm -rf /Volumes/GRISP/*",
-            # destination: "tmp/grisp"
-            # post_script: "diskutil unmount /Volumes/GRISP",
-          ]
-        ]
-      end
-    """
-  end
+  defp grisp_snippet(config), do: Snippets.grisp_function(config)
 
-  defp releases_snippet(config) do
-    """
-      def releases do
-        [
-          {:#{config.name},
-            [
-              overwrite: true,
-              cookie: "#{config.cookie || "grisp"}",
-              include_erts: &MixGrisp.Release.erts/0,
-              steps: [&MixGrisp.Release.init/1, :assemble],
-              include_executables_for: [],
-              strip_beams: Mix.env() == :prod
-            ]}
-        ]
-      end
-    """
-  end
+  defp releases_snippet(config), do: Snippets.releases_function(config)
 
   defp manual_steps(config) do
     steps = [
@@ -183,22 +156,9 @@ defmodule MixGrisp.Configure.MixExsPatcher do
       releases_snippet(config)
     ]
 
-    if config.epmd do
-      steps ++
-        [
-          """
-          Add to deps/0:
-            {:epmd, git: "https://github.com/erlang/epmd", ref: "4d1a59", runtime: false}
-          """,
-          """
-          Add epmd to your application config so its modules are available at runtime:
-            extra_applications: [:logger]
-            included_applications: [:epmd]
-          """
-        ]
-    else
-      steps
-    end
+    steps
+    |> maybe_add_epmd_manual_steps(config)
+    |> maybe_add_grisp_io_manual_steps(config)
   end
 
   defp remaining_manual_steps(%{epmd: true}) do
@@ -212,4 +172,26 @@ defmodule MixGrisp.Configure.MixExsPatcher do
   end
 
   defp remaining_manual_steps(_config), do: []
+
+  defp maybe_add_epmd_manual_steps(steps, %{epmd: true}) do
+    steps ++
+      [
+        """
+        Add to deps/0:
+          #{Snippets.epmd_dependency()}
+        """,
+        Snippets.epmd_application_manual_step()
+      ]
+  end
+
+  defp maybe_add_epmd_manual_steps(steps, _config), do: steps
+
+  defp maybe_add_grisp_io_manual_steps(steps, %{grisp_io: true}) do
+    steps ++
+      [
+        Snippets.grisp_io_dependencies_manual_step()
+      ]
+  end
+
+  defp maybe_add_grisp_io_manual_steps(steps, _config), do: steps
 end

--- a/lib/mix_grisp/configure/prompter.ex
+++ b/lib/mix_grisp/configure/prompter.ex
@@ -19,6 +19,7 @@ defmodule MixGrisp.Configure.Prompter do
     |> maybe_prompt_grisp_io_linking(ask)
     |> maybe_prompt_token(ask)
     |> maybe_prompt_epmd(ask)
+    |> maybe_prompt_node_name(ask)
     |> maybe_prompt_cookie(ask)
   end
 
@@ -75,6 +76,12 @@ defmodule MixGrisp.Configure.Prompter do
   end
 
   defp maybe_prompt_epmd(config, _ask), do: config
+
+  defp maybe_prompt_node_name(%{epmd: true, node_name: nil} = config, ask) do
+    Map.put(config, :node_name, ask_string(ask, "Erlang distribution node name"))
+  end
+
+  defp maybe_prompt_node_name(config, _ask), do: config
 
   defp maybe_prompt_cookie(%{epmd: true, cookie: nil} = config, ask) do
     Map.put(config, :cookie, ask_optional_string(ask, "Erlang distribution cookie"))

--- a/lib/mix_grisp/configure/prompter.ex
+++ b/lib/mix_grisp/configure/prompter.ex
@@ -1,0 +1,123 @@
+defmodule MixGrisp.Configure.Prompter do
+  @moduledoc false
+
+  def maybe_prompt(config, opts \\ [])
+  def maybe_prompt(%{interactive: false} = config, _opts), do: config
+
+  def maybe_prompt(config, opts) when is_map(config) and is_list(opts) do
+    ask = Keyword.get(opts, :ask, &default_ask/1)
+
+    # Some prompted values are currently validated for future use, but the generated
+    # setup assets still remain canonical placeholders and are not personalized yet.
+    config
+    |> maybe_prompt_name(ask)
+    |> maybe_prompt_network(ask)
+    |> maybe_prompt_network_type(ask)
+    |> maybe_prompt_ssid(ask)
+    |> maybe_prompt_psk(ask)
+    |> maybe_prompt_grisp_io(ask)
+    |> maybe_prompt_grisp_io_linking(ask)
+    |> maybe_prompt_token(ask)
+    |> maybe_prompt_epmd(ask)
+    |> maybe_prompt_cookie(ask)
+  end
+
+  defp maybe_prompt_name(%{name: nil} = config, ask) do
+    Map.put(config, :name, ask_string(ask, "OTP application name"))
+  end
+
+  defp maybe_prompt_name(config, _ask), do: config
+
+  defp maybe_prompt_network(%{network: false} = config, ask) do
+    Map.put(config, :network, ask_boolean(ask, "Enable network configuration?", false))
+  end
+
+  defp maybe_prompt_network(config, _ask), do: config
+
+  defp maybe_prompt_network_type(%{network: true, network_type: nil} = config, ask) do
+    Map.put(config, :network_type, ask_network_type(ask))
+  end
+
+  defp maybe_prompt_network_type(config, _ask), do: config
+
+  defp maybe_prompt_ssid(%{network_type: "wifi", ssid: nil} = config, ask) do
+    Map.put(config, :ssid, ask_optional_string(ask, "Wi-Fi SSID"))
+  end
+
+  defp maybe_prompt_ssid(config, _ask), do: config
+
+  defp maybe_prompt_psk(%{network_type: "wifi", psk: nil} = config, ask) do
+    Map.put(config, :psk, ask_optional_string(ask, "Wi-Fi PSK"))
+  end
+
+  defp maybe_prompt_psk(config, _ask), do: config
+
+  defp maybe_prompt_grisp_io(%{network: true, grisp_io: false} = config, ask) do
+    Map.put(config, :grisp_io, ask_boolean(ask, "Enable GRiSP.io integration?", false))
+  end
+
+  defp maybe_prompt_grisp_io(config, _ask), do: config
+
+  defp maybe_prompt_grisp_io_linking(%{grisp_io: true, grisp_io_linking: false} = config, ask) do
+    Map.put(config, :grisp_io_linking, ask_boolean(ask, "Enable GRiSP.io linking?", false))
+  end
+
+  defp maybe_prompt_grisp_io_linking(config, _ask), do: config
+
+  defp maybe_prompt_token(%{grisp_io_linking: true, token: nil} = config, ask) do
+    Map.put(config, :token, ask_optional_string(ask, "GRiSP.io linking token"))
+  end
+
+  defp maybe_prompt_token(config, _ask), do: config
+
+  defp maybe_prompt_epmd(%{network: true, epmd: false} = config, ask) do
+    Map.put(config, :epmd, ask_boolean(ask, "Enable epmd configuration?", false))
+  end
+
+  defp maybe_prompt_epmd(config, _ask), do: config
+
+  defp maybe_prompt_cookie(%{epmd: true, cookie: nil} = config, ask) do
+    Map.put(config, :cookie, ask_optional_string(ask, "Erlang distribution cookie"))
+  end
+
+  defp maybe_prompt_cookie(config, _ask), do: config
+
+  defp ask_string(ask, label) do
+    case ask.(label <> ": ") |> String.trim() do
+      "" -> nil
+      value -> value
+    end
+  end
+
+  defp ask_optional_string(ask, label) do
+    case ask.(label <> " (leave blank to skip): ") |> String.trim() do
+      "" -> nil
+      value -> value
+    end
+  end
+
+  defp ask_boolean(ask, label, default) do
+    default_hint = if default, do: "Y/n", else: "y/N"
+
+    case ask.("#{label} [#{default_hint}]: ") |> String.trim() |> String.downcase() do
+      "" -> default
+      "y" -> true
+      "yes" -> true
+      "true" -> true
+      "n" -> false
+      "no" -> false
+      "false" -> false
+      other -> Mix.raise("Invalid prompt response: #{inspect(other)}")
+    end
+  end
+
+  defp ask_network_type(ask) do
+    case ask.("Network type? [ethernet/wifi]: ") |> String.trim() |> String.downcase() do
+      "ethernet" -> "ethernet"
+      "wifi" -> "wifi"
+      other -> Mix.raise("Invalid network type: #{inspect(other)}")
+    end
+  end
+
+  defp default_ask(prompt), do: Mix.shell().prompt(prompt)
+end

--- a/lib/mix_grisp/configure/renderer.ex
+++ b/lib/mix_grisp/configure/renderer.ex
@@ -1,0 +1,44 @@
+defmodule MixGrisp.Configure.Renderer do
+  @moduledoc false
+
+  def apply(plan, config, opts \\ []) when is_list(plan) and is_map(config) do
+    root = Keyword.get(opts, :root, File.cwd!())
+
+    Enum.reduce(plan, %{created: [], skipped: []}, fn entry, acc ->
+      render_entry(entry, config, root, acc)
+    end)
+  end
+
+  defp render_entry(%{template: template, target: target}, _config, root, acc) do
+    target_path = Path.join(root, target)
+
+    if File.exists?(target_path) do
+      %{acc | skipped: [target | acc.skipped]}
+    else
+      # For now these setup assets are copied as canonical placeholders.
+      # Personalizing them from configure state can be added later if needed.
+      template
+      |> template_path()
+      |> File.read!()
+      |> then(&write_rendered(target_path, &1))
+
+      %{acc | created: [target | acc.created]}
+    end
+  end
+
+  defp template_path(template) do
+    :mix_grisp
+    |> :code.priv_dir()
+    |> List.to_string()
+    |> Path.join("templates")
+    |> Path.join(template)
+  end
+
+  defp write_rendered(path, contents) do
+    path
+    |> Path.dirname()
+    |> File.mkdir_p!()
+
+    File.write!(path, contents)
+  end
+end

--- a/lib/mix_grisp/configure/renderer.ex
+++ b/lib/mix_grisp/configure/renderer.ex
@@ -27,11 +27,13 @@ defmodule MixGrisp.Configure.Renderer do
 
   defp template_contents("grisp/grisp2/common/deploy/files/grisp.ini.mustache" = template, config) do
     # Keep the base GRiSP.ini canonical and add the Wi-Fi-specific `wpa=` line only
-    # when the user selected Wi-Fi networking.
+    # when the user selected Wi-Fi networking. Likewise, append the epmd/distribution
+    # flags only when that feature is enabled.
     template
     |> template_path()
     |> File.read!()
     |> maybe_add_wpa_line(config)
+    |> maybe_add_epmd_flags(config)
   end
 
   defp template_contents(template, _config) do
@@ -61,4 +63,13 @@ defmodule MixGrisp.Configure.Renderer do
   end
 
   defp maybe_add_wpa_line(contents, _config), do: contents
+
+  defp maybe_add_epmd_flags(contents, %{epmd: true, node_name: node_name, cookie: cookie}) do
+    flags =
+      ~s( -kernel inetrc "./erl_inetrc" -internal_epmd epmd_sup -sname #{node_name} -setcookie #{cookie || "grisp"})
+
+    String.replace(contents, " -extra --no-halt", flags <> " -extra --no-halt")
+  end
+
+  defp maybe_add_epmd_flags(contents, _config), do: contents
 end

--- a/lib/mix_grisp/configure/renderer.ex
+++ b/lib/mix_grisp/configure/renderer.ex
@@ -9,7 +9,7 @@ defmodule MixGrisp.Configure.Renderer do
     end)
   end
 
-  defp render_entry(%{template: template, target: target}, _config, root, acc) do
+  defp render_entry(%{template: template, target: target}, config, root, acc) do
     target_path = Path.join(root, target)
 
     if File.exists?(target_path) do
@@ -18,12 +18,26 @@ defmodule MixGrisp.Configure.Renderer do
       # For now these setup assets are copied as canonical placeholders.
       # Personalizing them from configure state can be added later if needed.
       template
-      |> template_path()
-      |> File.read!()
+      |> template_contents(config)
       |> then(&write_rendered(target_path, &1))
 
       %{acc | created: [target | acc.created]}
     end
+  end
+
+  defp template_contents("grisp/grisp2/common/deploy/files/grisp.ini.mustache" = template, config) do
+    # Keep the base GRiSP.ini canonical and add the Wi-Fi-specific `wpa=` line only
+    # when the user selected Wi-Fi networking.
+    template
+    |> template_path()
+    |> File.read!()
+    |> maybe_add_wpa_line(config)
+  end
+
+  defp template_contents(template, _config) do
+    template
+    |> template_path()
+    |> File.read!()
   end
 
   defp template_path(template) do
@@ -41,4 +55,10 @@ defmodule MixGrisp.Configure.Renderer do
 
     File.write!(path, contents)
   end
+
+  defp maybe_add_wpa_line(contents, %{network_type: "wifi"}) do
+    String.replace(contents, "wlan=enable\n", "wlan=enable\nwpa=wpa_supplicant.conf\n")
+  end
+
+  defp maybe_add_wpa_line(contents, _config), do: contents
 end

--- a/lib/mix_grisp/configure/snippets.ex
+++ b/lib/mix_grisp/configure/snippets.ex
@@ -1,0 +1,96 @@
+defmodule MixGrisp.Configure.Snippets do
+  @moduledoc false
+
+  def grisp_function(config) do
+    """
+      def grisp do
+        [
+          otp: [version: "#{config.otp_version}"],
+          deploy: [
+            # pre_script: "rm -rf /Volumes/GRISP/*",
+            # destination: "tmp/grisp"
+            # post_script: "diskutil unmount /Volumes/GRISP",
+          ]
+        ]
+      end
+    """
+  end
+
+  def releases_function(config) do
+    """
+      def releases do
+        [
+          {:#{config.name},
+            [
+              overwrite: true,
+              cookie: "#{config.cookie || "grisp"}",
+              include_erts: &MixGrisp.Release.erts/0,
+              steps: [&MixGrisp.Release.init/1, :assemble],
+              include_executables_for: [],
+              strip_beams: Mix.env() == :prod
+            ]}
+        ]
+      end
+    """
+  end
+
+  def epmd_dependency do
+    ~s({:epmd, git: "https://github.com/erlang/epmd", ref: "4d1a59", runtime: false})
+  end
+
+  def epmd_application_manual_step do
+    """
+    Add epmd to your application config so its modules are available at runtime:
+      extra_applications: [:logger]
+      included_applications: [:epmd]
+    """
+  end
+
+  def grisp_io_dependencies_manual_step do
+    """
+    Add the GRiSP.io runtime dependencies to deps/0 with versions that match your GRiSP stack:
+      {:certifi, ...}
+      {:grisp_cryptoauth, ...}
+      {:grisp_updater_grisp2, ...}
+      {:grisp_connect, ...}
+    """
+  end
+
+  def grisp_io_config(config) do
+    linking_line =
+      if config.grisp_io_linking and config.token do
+        ~s(  device_linking_token: "#{config.token}",\n)
+      else
+        ""
+      end
+
+    """
+    config :grisp_keychain,
+      api_module: :grisp_cryptoauth
+
+    config :grisp_cryptoauth,
+      tls_server_trusted_certs_cb: {:certifi, :cacerts, []}
+
+    config :grisp_connect,
+    #{linking_line}  logger: []
+
+    config :grisp_updater,
+      system: {:grisp_updater_grisp2, %{}},
+      sources: [
+        {:grisp_updater_tarball, %{}},
+        {:grisp_updater_http, %{backend: {:grisp_updater_grisp2, %{}}}}
+      ]
+
+    config :kernel,
+      logger_level: :notice
+    """
+  end
+
+  def grisp_io_config_manual_step(config) do
+    """
+    Add the GRiSP.io runtime config to config/config.exs:
+
+    #{grisp_io_config(config)}
+    """
+  end
+end

--- a/lib/mix_grisp/configure/template_plan.ex
+++ b/lib/mix_grisp/configure/template_plan.ex
@@ -1,0 +1,51 @@
+defmodule MixGrisp.Configure.TemplatePlan do
+  @moduledoc false
+
+  def build(config) when is_map(config) do
+    [
+      %{
+        template: "config/config.exs",
+        target: "config/config.exs"
+      }
+    ]
+    |> maybe_add_network(config)
+    |> maybe_add_wifi(config)
+    |> maybe_add_erl_inetrc(config)
+  end
+
+  defp maybe_add_network(plan, %{network: true}) do
+    plan ++
+      [
+        %{
+          template: "grisp/grisp2/common/deploy/files/grisp.ini.mustache",
+          target: "grisp/grisp2/common/deploy/files/grisp.ini.mustache"
+        }
+      ]
+  end
+
+  defp maybe_add_network(plan, _config), do: plan
+
+  defp maybe_add_wifi(plan, %{wifi: true}) do
+    plan ++
+      [
+        %{
+          template: "grisp/grisp2/common/deploy/files/wpa_supplicant.conf",
+          target: "grisp/grisp2/common/deploy/files/wpa_supplicant.conf"
+        }
+      ]
+  end
+
+  defp maybe_add_wifi(plan, _config), do: plan
+
+  defp maybe_add_erl_inetrc(plan, %{network: true, grisp_io: false}) do
+    plan ++
+      [
+        %{
+          template: "grisp/grisp2/common/deploy/files/erl_inetrc",
+          target: "grisp/grisp2/common/deploy/files/erl_inetrc"
+        }
+      ]
+  end
+
+  defp maybe_add_erl_inetrc(plan, _config), do: plan
+end

--- a/lib/mix_grisp/configure/template_plan.ex
+++ b/lib/mix_grisp/configure/template_plan.ex
@@ -25,7 +25,7 @@ defmodule MixGrisp.Configure.TemplatePlan do
 
   defp maybe_add_network(plan, _config), do: plan
 
-  defp maybe_add_wifi(plan, %{wifi: true}) do
+  defp maybe_add_wifi(plan, %{network_type: "wifi"}) do
     plan ++
       [
         %{

--- a/lib/mix_grisp/configure/validator.ex
+++ b/lib/mix_grisp/configure/validator.ex
@@ -1,0 +1,62 @@
+defmodule MixGrisp.Configure.Validator do
+  @moduledoc false
+
+  @optional_string_keys [:destination, :ssid, :psk, :token, :cookie]
+
+  def normalize(config) when is_map(config) do
+    Enum.reduce(@optional_string_keys, config, fn key, acc ->
+      Map.update(acc, key, nil, &normalize_optional_string/1)
+    end)
+    |> Map.update(:name, nil, &normalize_name/1)
+  end
+
+  def validate!(config) when is_map(config) do
+    config = normalize(config)
+
+    cond do
+      blank_name?(config.name) ->
+        Mix.raise("--name cannot be blank")
+
+      config.wifi && !config.network ->
+        Mix.raise("--wifi requires --network")
+
+      present?(config.ssid) && !config.wifi ->
+        Mix.raise("--ssid requires --wifi")
+
+      present?(config.psk) && !config.wifi ->
+        Mix.raise("--psk requires --wifi")
+
+      config.grisp_io && !config.network ->
+        Mix.raise("--grisp-io requires --network")
+
+      config.grisp_io_linking && !config.grisp_io ->
+        Mix.raise("--grisp-io-linking requires --grisp-io")
+
+      present?(config.token) && !config.grisp_io_linking ->
+        Mix.raise("--token requires --grisp-io-linking")
+
+      present?(config.cookie) && !config.epmd ->
+        Mix.raise("--cookie requires --epmd")
+
+      true ->
+        config
+    end
+  end
+
+  defp normalize_optional_string(value) do
+    value
+    |> normalize_string()
+    |> case do
+      "" -> nil
+      normalized -> normalized
+    end
+  end
+
+  defp blank_name?(value), do: value in ["", nil]
+  defp present?(value), do: not is_nil(value)
+
+  defp normalize_name(value), do: normalize_string(value)
+
+  defp normalize_string(value) when is_binary(value), do: String.trim(value)
+  defp normalize_string(value), do: value
+end

--- a/lib/mix_grisp/configure/validator.ex
+++ b/lib/mix_grisp/configure/validator.ex
@@ -1,7 +1,7 @@
 defmodule MixGrisp.Configure.Validator do
   @moduledoc false
 
-  @optional_string_keys [:destination, :ssid, :psk, :token, :cookie]
+  @optional_string_keys [:destination, :network_type, :ssid, :psk, :token, :cookie]
 
   def normalize(config) when is_map(config) do
     Enum.reduce(@optional_string_keys, config, fn key, acc ->
@@ -17,14 +17,17 @@ defmodule MixGrisp.Configure.Validator do
       blank_name?(config.name) ->
         Mix.raise("--name cannot be blank")
 
-      config.wifi && !config.network ->
-        Mix.raise("--wifi requires --network")
+      invalid_network_type?(config.network_type) ->
+        Mix.raise("--network-type must be either ethernet or wifi")
 
-      present?(config.ssid) && !config.wifi ->
-        Mix.raise("--ssid requires --wifi")
+      present?(config.network_type) && !config.network ->
+        Mix.raise("--network-type requires --network")
 
-      present?(config.psk) && !config.wifi ->
-        Mix.raise("--psk requires --wifi")
+      present?(config.ssid) && config.network_type != "wifi" ->
+        Mix.raise("--ssid requires --network-type wifi")
+
+      present?(config.psk) && config.network_type != "wifi" ->
+        Mix.raise("--psk requires --network-type wifi")
 
       config.grisp_io && !config.network ->
         Mix.raise("--grisp-io requires --network")
@@ -53,6 +56,7 @@ defmodule MixGrisp.Configure.Validator do
   end
 
   defp blank_name?(value), do: value in ["", nil]
+  defp invalid_network_type?(value), do: present?(value) and value not in ["ethernet", "wifi"]
   defp present?(value), do: not is_nil(value)
 
   defp normalize_name(value), do: normalize_string(value)

--- a/lib/mix_grisp/configure/validator.ex
+++ b/lib/mix_grisp/configure/validator.ex
@@ -1,7 +1,7 @@
 defmodule MixGrisp.Configure.Validator do
   @moduledoc false
 
-  @optional_string_keys [:destination, :network_type, :ssid, :psk, :token, :cookie]
+  @optional_string_keys [:destination, :network_type, :ssid, :psk, :token, :node_name, :cookie]
 
   def normalize(config) when is_map(config) do
     Enum.reduce(@optional_string_keys, config, fn key, acc ->
@@ -40,6 +40,12 @@ defmodule MixGrisp.Configure.Validator do
 
       present?(config.cookie) && !config.epmd ->
         Mix.raise("--cookie requires --epmd")
+
+      present?(config.node_name) && !config.epmd ->
+        Mix.raise("--node-name requires --epmd")
+
+      config.epmd && !present?(config.node_name) ->
+        Mix.raise("--node-name is required when --epmd is enabled")
 
       true ->
         config

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule MixGrisp.MixProject do
 
   defp package() do
     [
-      files: ~w(lib .formatter.exs mix.exs README* LICENSE*),
+      files: ~w(lib priv .formatter.exs mix.exs README* LICENSE*),
       licenses: ["Apache 2.0"],
       links: %{
         "GitHub" => @source_url,

--- a/priv/templates/config/config.exs
+++ b/priv/templates/config/config.exs
@@ -1,0 +1,1 @@
+import Config

--- a/priv/templates/grisp/grisp2/common/deploy/files/erl_inetrc
+++ b/priv/templates/grisp/grisp2/common/deploy/files/erl_inetrc
@@ -1,0 +1,13 @@
+%--- Erlang Inet Configuration -------------------------------------------------
+
+% Add hosts
+% {host, {X,X,X,X}, ["Host"]}.
+
+% Do not monitor the hosts file
+{hosts_file, ""}.
+
+% Disable caching
+{cache_size, 0}.
+
+% Specify lookup method
+{lookup, [file, dns]}.

--- a/priv/templates/grisp/grisp2/common/deploy/files/grisp.ini.mustache
+++ b/priv/templates/grisp/grisp2/common/deploy/files/grisp.ini.mustache
@@ -6,4 +6,3 @@ shell = none
 ip_self=dhcp
 wlan=enable
 hostname=GRISP_HOSTNAME
-wpa=wpa_supplicant.conf

--- a/priv/templates/grisp/grisp2/common/deploy/files/grisp.ini.mustache
+++ b/priv/templates/grisp/grisp2/common/deploy/files/grisp.ini.mustache
@@ -1,0 +1,9 @@
+[erlang]
+args = erl.rtems -C multi_time_warp -- -mode embedded -home . -pa . -root {{release_name}} -bindir {{release_name}}/erts-{{erts_vsn}}/bin -boot {{release_name}}/releases/{{release_version}}/start -boot_var RELEASE_LIB {{release_name}}/lib  -config {{release_name}}/releases/{{release_version}}/sys.config -s elixir start_iex -extra --no-halt
+shell = none
+
+[network]
+ip_self=dhcp
+wlan=enable
+hostname=GRISP_HOSTNAME
+wpa=wpa_supplicant.conf

--- a/priv/templates/grisp/grisp2/common/deploy/files/wpa_supplicant.conf
+++ b/priv/templates/grisp/grisp2/common/deploy/files/wpa_supplicant.conf
@@ -1,0 +1,5 @@
+network={
+    ssid="WLAN_SSID"
+    key_mgmt=WPA-PSK
+    psk="WLAN_PASSWORD"
+}

--- a/test/mix/tasks/grisp/configure_test.exs
+++ b/test/mix/tasks/grisp/configure_test.exs
@@ -1,0 +1,103 @@
+defmodule Mix.Tasks.Grisp.ConfigureTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    Mix.Task.reenable("grisp.configure")
+    Mix.shell(Mix.Shell.Process)
+
+    root =
+      System.tmp_dir!()
+      |> Path.join("mix_grisp_task_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(root)
+
+    on_exit(fn ->
+      File.rm_rf!(root)
+      Mix.shell(Mix.Shell.IO)
+    end)
+
+    {:ok, root: root}
+  end
+
+  test "non-interactive mode creates the selected scaffold files", %{root: root} do
+    File.cd!(root, fn ->
+      Mix.Tasks.Grisp.Configure.run([
+        "--interactive",
+        "false",
+        "--name",
+        "demo",
+        "--network",
+        "true",
+        "--wifi",
+        "true"
+      ])
+    end)
+
+    assert_received {:mix_shell, :info, ["Created config/config.exs"]}
+    assert_received {:mix_shell, :info, ["Created grisp/grisp2/common/deploy/files/grisp.ini.mustache"]}
+    assert_received {:mix_shell, :info, ["Created grisp/grisp2/common/deploy/files/wpa_supplicant.conf"]}
+    assert_received {:mix_shell, :info, ["Created grisp/grisp2/common/deploy/files/erl_inetrc"]}
+
+    assert File.exists?(Path.join(root, "config/config.exs"))
+    assert File.exists?(Path.join(root, "grisp/grisp2/common/deploy/files/grisp.ini.mustache"))
+    assert File.exists?(Path.join(root, "grisp/grisp2/common/deploy/files/wpa_supplicant.conf"))
+    assert File.exists?(Path.join(root, "grisp/grisp2/common/deploy/files/erl_inetrc"))
+  end
+
+  test "rerunning in non-interactive mode reports skipped files", %{root: root} do
+    args = [
+      "--interactive",
+      "false",
+      "--name",
+      "demo",
+      "--network",
+      "true"
+    ]
+
+    File.cd!(root, fn ->
+      Mix.Tasks.Grisp.Configure.run(args)
+      Mix.Task.reenable("grisp.configure")
+      Mix.Tasks.Grisp.Configure.run(args)
+    end)
+
+    assert_received {:mix_shell, :info, ["Skipped config/config.exs"]}
+    assert_received {:mix_shell, :info, ["Skipped grisp/grisp2/common/deploy/files/grisp.ini.mustache"]}
+    assert_received {:mix_shell, :info, ["Skipped grisp/grisp2/common/deploy/files/erl_inetrc"]}
+  end
+
+  test "interactive mode is explicitly rejected for now", %{root: root} do
+    assert_raise Mix.Error, "Interactive mode is not implemented yet. Use --interactive false.", fn ->
+      File.cd!(root, fn ->
+        Mix.Tasks.Grisp.Configure.run(["--name", "demo"])
+      end)
+    end
+  end
+
+  test "invalid boolean values are rejected", %{root: root} do
+    assert_raise Mix.Error, ~s(Invalid boolean value: "maybe"), fn ->
+      File.cd!(root, fn ->
+        Mix.Tasks.Grisp.Configure.run([
+          "--interactive",
+          "maybe",
+          "--name",
+          "demo"
+        ])
+      end)
+    end
+  end
+
+  test "unknown options are rejected", %{root: root} do
+    assert_raise Mix.Error, "Invalid options: --unknown", fn ->
+      File.cd!(root, fn ->
+        Mix.Tasks.Grisp.Configure.run([
+          "--interactive",
+          "false",
+          "--name",
+          "demo",
+          "--unknown",
+          "value"
+        ])
+      end)
+    end
+  end
+end

--- a/test/mix/tasks/grisp/configure_test.exs
+++ b/test/mix/tasks/grisp/configure_test.exs
@@ -263,4 +263,57 @@ defmodule Mix.Tasks.Grisp.ConfigureTest do
     assert grisp_ini =~ "-sname mynode"
     assert grisp_ini =~ "-setcookie mycookie"
   end
+
+  test "fixture-like non-interactive grisp_io setup patches config/config.exs", %{root: root} do
+    File.write!(Path.join(root, "mix.exs"), """
+    defmodule Demo.MixProject do
+      use Mix.Project
+
+      def project do
+        [
+          app: :demo,
+          version: "0.1.0",
+          deps: deps()
+        ]
+      end
+
+      def application do
+        [
+          extra_applications: [:logger]
+        ]
+      end
+
+      defp deps do
+        []
+      end
+    end
+    """)
+
+    File.cd!(root, fn ->
+      Mix.Tasks.Grisp.Configure.run([
+        "--interactive",
+        "false",
+        "--name",
+        "demo",
+        "--network",
+        "true",
+        "--network-type",
+        "wifi",
+        "--grisp-io",
+        "true",
+        "--grisp-io-linking",
+        "true",
+        "--token",
+        "link-token"
+      ])
+    end)
+
+    config_exs = File.read!(Path.join(root, "config/config.exs"))
+
+    assert_received {:mix_shell, :info, ["Updated config/config.exs"]}
+    assert config_exs =~ "config :grisp_keychain"
+    assert config_exs =~ "config :grisp_connect"
+    assert config_exs =~ ~s(device_linking_token: "link-token")
+    assert config_exs =~ "config :grisp_updater"
+  end
 end

--- a/test/mix/tasks/grisp/configure_test.exs
+++ b/test/mix/tasks/grisp/configure_test.exs
@@ -37,6 +37,7 @@ defmodule Mix.Tasks.Grisp.ConfigureTest do
     assert_received {:mix_shell, :info, ["Created grisp/grisp2/common/deploy/files/grisp.ini.mustache"]}
     assert_received {:mix_shell, :info, ["Created grisp/grisp2/common/deploy/files/wpa_supplicant.conf"]}
     assert_received {:mix_shell, :info, ["Created grisp/grisp2/common/deploy/files/erl_inetrc"]}
+    assert_received {:mix_shell, :info, ["Could not safely update mix.exs automatically."]}
 
     assert File.exists?(Path.join(root, "config/config.exs"))
     assert File.exists?(Path.join(root, "grisp/grisp2/common/deploy/files/grisp.ini.mustache"))
@@ -154,5 +155,112 @@ defmodule Mix.Tasks.Grisp.ConfigureTest do
         ])
       end)
     end
+  end
+
+  test "configure updates a simple mix.exs automatically", %{root: root} do
+    File.write!(Path.join(root, "mix.exs"), """
+    defmodule Demo.MixProject do
+      use Mix.Project
+
+      def project do
+        [
+          app: :demo,
+          version: "0.1.0",
+          deps: deps()
+        ]
+      end
+
+      def application do
+        [
+          extra_applications: [:logger]
+        ]
+      end
+
+      defp deps do
+        []
+      end
+    end
+    """)
+
+    File.cd!(root, fn ->
+      Mix.Tasks.Grisp.Configure.run([
+        "--interactive",
+        "false",
+        "--name",
+        "demo",
+        "--network",
+        "true",
+        "--epmd",
+        "true",
+        "--node-name",
+        "mynode",
+        "--cookie",
+        "grisp"
+      ])
+    end)
+
+    patched = File.read!(Path.join(root, "mix.exs"))
+
+    assert_received {:mix_shell, :info, ["Updated mix.exs"]}
+    assert patched =~ "grisp: grisp()"
+    assert patched =~ "releases: releases()"
+    assert patched =~ ~s({:grisp, "~> 2.4"})
+    assert patched =~ ~s({:epmd, git: "https://github.com/erlang/epmd", ref: "4d1a59", runtime: false})
+    assert patched =~ "included_applications: [:epmd]"
+  end
+
+  test "fixture-like non-interactive epmd setup updates mix.exs and grisp.ini", %{root: root} do
+    File.write!(Path.join(root, "mix.exs"), """
+    defmodule Demo.MixProject do
+      use Mix.Project
+
+      def project do
+        [
+          app: :demo,
+          version: "0.1.0",
+          deps: deps()
+        ]
+      end
+
+      def application do
+        [
+          extra_applications: [:logger]
+        ]
+      end
+
+      defp deps do
+        []
+      end
+    end
+    """)
+
+    File.cd!(root, fn ->
+      Mix.Tasks.Grisp.Configure.run([
+        "--interactive",
+        "false",
+        "--name",
+        "demo",
+        "--network",
+        "true",
+        "--network-type",
+        "ethernet",
+        "--epmd",
+        "true",
+        "--node-name",
+        "mynode",
+        "--cookie",
+        "mycookie"
+      ])
+    end)
+
+    patched = File.read!(Path.join(root, "mix.exs"))
+    grisp_ini = File.read!(Path.join(root, "grisp/grisp2/common/deploy/files/grisp.ini.mustache"))
+
+    assert patched =~ ~s({:epmd, git: "https://github.com/erlang/epmd", ref: "4d1a59", runtime: false})
+    assert patched =~ "included_applications: [:epmd]"
+    assert grisp_ini =~ ~s(-kernel inetrc "./erl_inetrc")
+    assert grisp_ini =~ "-internal_epmd epmd_sup"
+    assert grisp_ini =~ "-sname mynode"
+    assert grisp_ini =~ "-setcookie mycookie"
   end
 end

--- a/test/mix/tasks/grisp/configure_test.exs
+++ b/test/mix/tasks/grisp/configure_test.exs
@@ -28,8 +28,8 @@ defmodule Mix.Tasks.Grisp.ConfigureTest do
         "demo",
         "--network",
         "true",
-        "--wifi",
-        "true"
+        "--network-type",
+        "wifi"
       ])
     end)
 
@@ -65,12 +65,67 @@ defmodule Mix.Tasks.Grisp.ConfigureTest do
     assert_received {:mix_shell, :info, ["Skipped grisp/grisp2/common/deploy/files/erl_inetrc"]}
   end
 
-  test "interactive mode is explicitly rejected for now", %{root: root} do
-    assert_raise Mix.Error, "Interactive mode is not implemented yet. Use --interactive false.", fn ->
-      File.cd!(root, fn ->
-        Mix.Tasks.Grisp.Configure.run(["--name", "demo"])
-      end)
-    end
+  test "interactive mode prompts for missing values and creates files", %{root: root} do
+    send(self(), {:mix_shell_input, :prompt, "demo"})
+    send(self(), {:mix_shell_input, :prompt, "y"})
+    send(self(), {:mix_shell_input, :prompt, "wifi"})
+    send(self(), {:mix_shell_input, :prompt, "mywifi"})
+    send(self(), {:mix_shell_input, :prompt, "secret"})
+    send(self(), {:mix_shell_input, :prompt, "n"})
+    send(self(), {:mix_shell_input, :prompt, "n"})
+
+    File.cd!(root, fn ->
+      Mix.Tasks.Grisp.Configure.run([])
+    end)
+
+    assert_received {:mix_shell, :prompt, ["OTP application name: "]}
+    assert_received {:mix_shell, :prompt, ["Enable network configuration? [y/N]: "]}
+    assert_received {:mix_shell, :prompt, ["Network type? [ethernet/wifi]: "]}
+    assert_received {:mix_shell, :prompt, ["Wi-Fi SSID (leave blank to skip): "]}
+    assert_received {:mix_shell, :prompt, ["Wi-Fi PSK (leave blank to skip): "]}
+    assert_received {:mix_shell, :prompt, ["Enable GRiSP.io integration? [y/N]: "]}
+    assert_received {:mix_shell, :prompt, ["Enable epmd configuration? [y/N]: "]}
+
+    assert File.exists?(Path.join(root, "config/config.exs"))
+    assert File.exists?(Path.join(root, "grisp/grisp2/common/deploy/files/grisp.ini.mustache"))
+    assert File.exists?(Path.join(root, "grisp/grisp2/common/deploy/files/wpa_supplicant.conf"))
+    assert File.exists?(Path.join(root, "grisp/grisp2/common/deploy/files/erl_inetrc"))
+  end
+
+  test "interactive mode skips prompts for values already provided", %{root: root} do
+    send(self(), {:mix_shell_input, :prompt, "ethernet"})
+    send(self(), {:mix_shell_input, :prompt, "n"})
+    send(self(), {:mix_shell_input, :prompt, "n"})
+
+    File.cd!(root, fn ->
+      Mix.Tasks.Grisp.Configure.run([
+        "--name",
+        "demo",
+        "--network",
+        "true"
+      ])
+    end)
+
+    refute_received {:mix_shell, :prompt, ["OTP application name: "]}
+    refute_received {:mix_shell, :prompt, ["Enable network configuration? [y/N]: "]}
+    assert_received {:mix_shell, :prompt, ["Network type? [ethernet/wifi]: "]}
+    assert_received {:mix_shell, :prompt, ["Enable GRiSP.io integration? [y/N]: "]}
+    assert_received {:mix_shell, :prompt, ["Enable epmd configuration? [y/N]: "]}
+  end
+
+  test "interactive mode skips wifi detail prompts when wifi is disabled", %{root: root} do
+    send(self(), {:mix_shell_input, :prompt, "demo"})
+    send(self(), {:mix_shell_input, :prompt, "y"})
+    send(self(), {:mix_shell_input, :prompt, "ethernet"})
+    send(self(), {:mix_shell_input, :prompt, "n"})
+    send(self(), {:mix_shell_input, :prompt, "n"})
+
+    File.cd!(root, fn ->
+      Mix.Tasks.Grisp.Configure.run([])
+    end)
+
+    refute_received {:mix_shell, :prompt, ["Wi-Fi SSID (leave blank to skip): "]}
+    refute_received {:mix_shell, :prompt, ["Wi-Fi PSK (leave blank to skip): "]}
   end
 
   test "invalid boolean values are rejected", %{root: root} do

--- a/test/mix_grisp/configure/config_patcher_test.exs
+++ b/test/mix_grisp/configure/config_patcher_test.exs
@@ -1,0 +1,52 @@
+defmodule MixGrisp.Configure.ConfigPatcherTest do
+  use ExUnit.Case, async: true
+
+  alias MixGrisp.Configure
+  alias MixGrisp.Configure.ConfigPatcher
+
+  setup do
+    root =
+      System.tmp_dir!()
+      |> Path.join("mix_grisp_config_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(Path.join(root, "config"))
+    on_exit(fn -> File.rm_rf!(root) end)
+    {:ok, root: root}
+  end
+
+  test "patches config/config.exs for grisp_io", %{root: root} do
+    config_path = Path.join(root, "config/config.exs")
+    File.write!(config_path, "import Config\n")
+
+    config =
+      Configure.defaults()
+      |> Map.merge(%{
+        name: "demo",
+        interactive: false,
+        grisp_io: true,
+        grisp_io_linking: true,
+        token: "token"
+      })
+
+    result = ConfigPatcher.apply(config, root: root)
+    patched = File.read!(config_path)
+
+    assert result.status == :updated
+    assert patched =~ "config :grisp_keychain"
+    assert patched =~ "config :grisp_connect"
+    assert patched =~ ~s(device_linking_token: "token")
+    assert patched =~ "config :grisp_updater"
+  end
+
+  test "returns unchanged when grisp_io is disabled", %{root: root} do
+    config_path = Path.join(root, "config/config.exs")
+    File.write!(config_path, "import Config\n")
+
+    config = Configure.defaults() |> Map.merge(%{name: "demo", interactive: false})
+
+    result = ConfigPatcher.apply(config, root: root)
+
+    assert result.status == :unchanged
+    assert File.read!(config_path) == "import Config\n"
+  end
+end

--- a/test/mix_grisp/configure/mix_exs_patcher_test.exs
+++ b/test/mix_grisp/configure/mix_exs_patcher_test.exs
@@ -1,0 +1,80 @@
+defmodule MixGrisp.Configure.MixExsPatcherTest do
+  use ExUnit.Case, async: true
+
+  alias MixGrisp.Configure
+  alias MixGrisp.Configure.MixExsPatcher
+
+  setup do
+    root =
+      System.tmp_dir!()
+      |> Path.join("mix_grisp_mix_exs_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf!(root) end)
+    {:ok, root: root}
+  end
+
+  test "patches a simple mix new style mix.exs", %{root: root} do
+    mix_exs = Path.join(root, "mix.exs")
+
+    File.write!(mix_exs, """
+    defmodule Demo.MixProject do
+      use Mix.Project
+
+      def project do
+        [
+          app: :demo,
+          version: "0.1.0",
+          deps: deps()
+        ]
+      end
+
+      def application do
+        [
+          extra_applications: [:logger]
+        ]
+      end
+
+      defp deps do
+        []
+      end
+    end
+    """)
+
+    config =
+      Configure.defaults()
+      |> Map.merge(%{name: "demo", interactive: false, network: true, epmd: true, cookie: "grisp"})
+
+    result = MixExsPatcher.apply(config, root: root)
+    patched = File.read!(mix_exs)
+
+    assert result.status == :updated
+    assert patched =~ "grisp: grisp()"
+    assert patched =~ "releases: releases()"
+    assert patched =~ ~s({:grisp, "~> 2.4"})
+    assert patched =~ ~s({:epmd, git: "https://github.com/erlang/epmd", ref: "4d1a59", runtime: false})
+    assert patched =~ "included_applications: [:epmd]"
+    assert patched =~ "def grisp do"
+    assert patched =~ "def releases do"
+  end
+
+  test "returns manual steps for unsupported mix.exs shapes", %{root: root} do
+    mix_exs = Path.join(root, "mix.exs")
+
+    File.write!(mix_exs, """
+    defmodule Demo.MixProject do
+      use Mix.Project
+
+      def project, do: custom_project()
+      defp deps, do: custom_deps()
+    end
+    """)
+
+    config = Configure.defaults() |> Map.merge(%{name: "demo", interactive: false})
+
+    result = MixExsPatcher.apply(config, root: root)
+
+    assert result.status == :manual
+    assert Enum.any?(result.manual, &String.contains?(&1, "grisp: grisp()"))
+  end
+end

--- a/test/mix_grisp/configure/renderer_test.exs
+++ b/test/mix_grisp/configure/renderer_test.exs
@@ -1,0 +1,90 @@
+defmodule MixGrisp.Configure.RendererTest do
+  use ExUnit.Case, async: true
+
+  alias MixGrisp.Configure
+  alias MixGrisp.Configure.Renderer
+  alias MixGrisp.Configure.TemplatePlan
+
+  setup do
+    root =
+      System.tmp_dir!()
+      |> Path.join("mix_grisp_renderer_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf!(root) end)
+    {:ok, root: root}
+  end
+
+  test "renderer creates files for the selected plan", %{root: root} do
+    config =
+      Configure.defaults()
+      |> Map.merge(%{
+        name: "demo",
+        network: true,
+        wifi: true
+      })
+
+    plan = TemplatePlan.build(config)
+    result = Renderer.apply(plan, config, root: root)
+
+    assert Enum.sort(result.created) == Enum.sort(Enum.map(plan, & &1.target))
+    assert result.skipped == []
+
+    assert String.trim(File.read!(Path.join(root, "config/config.exs"))) == "import Config"
+
+    grisp_ini =
+      root
+      |> Path.join("grisp/grisp2/common/deploy/files/grisp.ini.mustache")
+      |> File.read!()
+
+    assert grisp_ini =~ "hostname=GRISP_HOSTNAME"
+    assert grisp_ini =~ "wpa=wpa_supplicant.conf"
+
+    wpa_supplicant =
+      root
+      |> Path.join("grisp/grisp2/common/deploy/files/wpa_supplicant.conf")
+      |> File.read!()
+
+    assert wpa_supplicant =~ ~s(ssid="WLAN_SSID")
+    assert wpa_supplicant =~ ~s(psk="WLAN_PASSWORD")
+  end
+
+  test "renderer skips files that already exist", %{root: root} do
+    config =
+      Configure.defaults()
+      |> Map.merge(%{
+        name: "demo",
+        network: true
+      })
+
+    plan = TemplatePlan.build(config)
+
+    first_run = Renderer.apply(plan, config, root: root)
+    second_run = Renderer.apply(plan, config, root: root)
+
+    assert first_run.skipped == []
+    assert Enum.sort(second_run.skipped) == Enum.sort(Enum.map(plan, & &1.target))
+    assert second_run.created == []
+  end
+
+  test "renderer omits inetrc flag when grisp_io is enabled", %{root: root} do
+    config =
+      Configure.defaults()
+      |> Map.merge(%{
+        name: "demo",
+        network: true,
+        grisp_io: true
+      })
+
+    plan = TemplatePlan.build(config)
+    Renderer.apply(plan, config, root: root)
+
+    grisp_ini =
+      root
+      |> Path.join("grisp/grisp2/common/deploy/files/grisp.ini.mustache")
+      |> File.read!()
+
+    assert grisp_ini =~ "-extra --no-halt"
+    refute File.exists?(Path.join(root, "grisp/grisp2/common/deploy/files/erl_inetrc"))
+  end
+end

--- a/test/mix_grisp/configure/renderer_test.exs
+++ b/test/mix_grisp/configure/renderer_test.exs
@@ -21,7 +21,7 @@ defmodule MixGrisp.Configure.RendererTest do
       |> Map.merge(%{
         name: "demo",
         network: true,
-        wifi: true
+        network_type: "wifi"
       })
 
     plan = TemplatePlan.build(config)
@@ -86,5 +86,26 @@ defmodule MixGrisp.Configure.RendererTest do
 
     assert grisp_ini =~ "-extra --no-halt"
     refute File.exists?(Path.join(root, "grisp/grisp2/common/deploy/files/erl_inetrc"))
+  end
+
+  test "renderer leaves grisp.ini without wpa line for ethernet", %{root: root} do
+    config =
+      Configure.defaults()
+      |> Map.merge(%{
+        name: "demo",
+        network: true,
+        network_type: "ethernet"
+      })
+
+    plan = TemplatePlan.build(config)
+    Renderer.apply(plan, config, root: root)
+
+    grisp_ini =
+      root
+      |> Path.join("grisp/grisp2/common/deploy/files/grisp.ini.mustache")
+      |> File.read!()
+
+    refute grisp_ini =~ "wpa=wpa_supplicant.conf"
+    refute File.exists?(Path.join(root, "grisp/grisp2/common/deploy/files/wpa_supplicant.conf"))
   end
 end

--- a/test/mix_grisp/configure/renderer_test.exs
+++ b/test/mix_grisp/configure/renderer_test.exs
@@ -108,4 +108,30 @@ defmodule MixGrisp.Configure.RendererTest do
     refute grisp_ini =~ "wpa=wpa_supplicant.conf"
     refute File.exists?(Path.join(root, "grisp/grisp2/common/deploy/files/wpa_supplicant.conf"))
   end
+
+  test "renderer adds epmd flags to grisp.ini when epmd is enabled", %{root: root} do
+    config =
+      Configure.defaults()
+      |> Map.merge(%{
+        name: "demo",
+        network: true,
+        network_type: "ethernet",
+        epmd: true,
+        node_name: "mynode",
+        cookie: "mycookie"
+      })
+
+    plan = TemplatePlan.build(config)
+    Renderer.apply(plan, config, root: root)
+
+    grisp_ini =
+      root
+      |> Path.join("grisp/grisp2/common/deploy/files/grisp.ini.mustache")
+      |> File.read!()
+
+    assert grisp_ini =~ ~s(-kernel inetrc "./erl_inetrc")
+    assert grisp_ini =~ "-internal_epmd epmd_sup"
+    assert grisp_ini =~ "-sname mynode"
+    assert grisp_ini =~ "-setcookie mycookie"
+  end
 end

--- a/test/mix_grisp/configure/template_plan_test.exs
+++ b/test/mix_grisp/configure/template_plan_test.exs
@@ -25,7 +25,7 @@ defmodule MixGrisp.Configure.TemplatePlanTest do
   end
 
   test "wifi plan adds wpa_supplicant.conf" do
-    assert targets_for(%{network: true, wifi: true}) == [
+    assert targets_for(%{network: true, network_type: "wifi"}) == [
              "config/config.exs",
              "grisp/grisp2/common/deploy/files/grisp.ini.mustache",
              "grisp/grisp2/common/deploy/files/wpa_supplicant.conf",

--- a/test/mix_grisp/configure/template_plan_test.exs
+++ b/test/mix_grisp/configure/template_plan_test.exs
@@ -1,0 +1,42 @@
+defmodule MixGrisp.Configure.TemplatePlanTest do
+  use ExUnit.Case, async: true
+
+  alias MixGrisp.Configure
+  alias MixGrisp.Configure.TemplatePlan
+
+  defp targets_for(overrides) do
+    Configure.defaults()
+    |> Map.merge(%{name: "demo"})
+    |> Map.merge(Map.new(overrides))
+    |> TemplatePlan.build()
+    |> Enum.map(& &1.target)
+  end
+
+  test "base plan only includes config/config.exs" do
+    assert targets_for(%{}) == ["config/config.exs"]
+  end
+
+  test "network plan adds grisp.ini and erl_inetrc" do
+    assert targets_for(%{network: true}) == [
+             "config/config.exs",
+             "grisp/grisp2/common/deploy/files/grisp.ini.mustache",
+             "grisp/grisp2/common/deploy/files/erl_inetrc"
+           ]
+  end
+
+  test "wifi plan adds wpa_supplicant.conf" do
+    assert targets_for(%{network: true, wifi: true}) == [
+             "config/config.exs",
+             "grisp/grisp2/common/deploy/files/grisp.ini.mustache",
+             "grisp/grisp2/common/deploy/files/wpa_supplicant.conf",
+             "grisp/grisp2/common/deploy/files/erl_inetrc"
+           ]
+  end
+
+  test "grisp_io skips erl_inetrc" do
+    assert targets_for(%{network: true, grisp_io: true}) == [
+             "config/config.exs",
+             "grisp/grisp2/common/deploy/files/grisp.ini.mustache"
+           ]
+  end
+end

--- a/test/mix_grisp/configure/validator_test.exs
+++ b/test/mix_grisp/configure/validator_test.exs
@@ -22,6 +22,7 @@ defmodule MixGrisp.Configure.ValidatorTest do
              grisp_io_linking: false,
              token: nil,
              epmd: false,
+             node_name: nil,
              cookie: nil
            } = Configure.defaults()
   end
@@ -130,6 +131,20 @@ defmodule MixGrisp.Configure.ValidatorTest do
     end
   end
 
+  test "validator rejects node_name without epmd" do
+    assert_raise Mix.Error, "--node-name requires --epmd", fn ->
+      %{base_config() | node_name: "mynode"}
+      |> Validator.validate!()
+    end
+  end
+
+  test "validator requires node_name when epmd is enabled" do
+    assert_raise Mix.Error, "--node-name is required when --epmd is enabled", fn ->
+      %{base_config() | epmd: true}
+      |> Validator.validate!()
+    end
+  end
+
   test "validator accepts a valid config" do
     config =
       Configure.defaults()
@@ -143,6 +158,7 @@ defmodule MixGrisp.Configure.ValidatorTest do
         grisp_io_linking: true,
         token: "token",
         epmd: true,
+        node_name: "mynode",
         cookie: "grisp"
       })
       |> Validator.validate!()
@@ -166,6 +182,7 @@ defmodule MixGrisp.Configure.ValidatorTest do
 
     assert config.token == nil
     assert config.cookie == nil
+    assert config.node_name == nil
     assert config.destination == nil
   end
 end

--- a/test/mix_grisp/configure/validator_test.exs
+++ b/test/mix_grisp/configure/validator_test.exs
@@ -1,0 +1,159 @@
+defmodule MixGrisp.Configure.ValidatorTest do
+  use ExUnit.Case, async: true
+
+  alias MixGrisp.Configure
+  alias MixGrisp.Configure.Validator
+
+  defp base_config do
+    %{Configure.defaults() | name: "demo"}
+  end
+
+  test "defaults returns the base configure state" do
+    assert %{
+             interactive: true,
+             name: nil,
+             otp_version: "27",
+             destination: nil,
+             network: false,
+             wifi: false,
+             ssid: nil,
+             psk: nil,
+             grisp_io: false,
+             grisp_io_linking: false,
+             token: nil,
+             epmd: false,
+             cookie: nil
+           } = Configure.defaults()
+  end
+
+  test "merge_cli merges options onto defaults and normalizes empty strings" do
+    config =
+      Configure.merge_cli(
+        name: "demo",
+        network: true,
+        ssid: "",
+        destination: ""
+      )
+
+    assert config.name == "demo"
+    assert config.network
+    assert config.ssid == nil
+    assert config.destination == nil
+    assert config.otp_version == "27"
+  end
+
+  test "merge_cli trims strings and normalizes whitespace-only optional values" do
+    config =
+      Configure.merge_cli(
+        name: "  demo  ",
+        ssid: "   ",
+        token: "  ",
+        destination: "  /tmp/grisp  "
+      )
+
+    assert config.name == "demo"
+    assert config.ssid == nil
+    assert config.token == nil
+    assert config.destination == "/tmp/grisp"
+  end
+
+  test "validator rejects blank name" do
+    assert_raise Mix.Error, "--name cannot be blank", fn ->
+      %{Configure.defaults() | name: ""}
+      |> Validator.validate!()
+    end
+  end
+
+  test "validator rejects whitespace-only name" do
+    assert_raise Mix.Error, "--name cannot be blank", fn ->
+      %{Configure.defaults() | name: "   "}
+      |> Validator.validate!()
+    end
+  end
+
+  test "validator rejects wifi without network" do
+    assert_raise Mix.Error, "--wifi requires --network", fn ->
+      %{base_config() | wifi: true}
+      |> Validator.validate!()
+    end
+  end
+
+  test "validator rejects ssid without wifi" do
+    assert_raise Mix.Error, "--ssid requires --wifi", fn ->
+      %{base_config() | ssid: "mywifi"}
+      |> Validator.validate!()
+    end
+  end
+
+  test "validator rejects psk without wifi" do
+    assert_raise Mix.Error, "--psk requires --wifi", fn ->
+      %{base_config() | psk: "secret"}
+      |> Validator.validate!()
+    end
+  end
+
+  test "validator rejects grisp_io without network" do
+    assert_raise Mix.Error, "--grisp-io requires --network", fn ->
+      %{base_config() | grisp_io: true}
+      |> Validator.validate!()
+    end
+  end
+
+  test "validator rejects grisp_io_linking without grisp_io" do
+    assert_raise Mix.Error, "--grisp-io-linking requires --grisp-io", fn ->
+      %{base_config() | grisp_io_linking: true}
+      |> Validator.validate!()
+    end
+  end
+
+  test "validator rejects token without grisp_io_linking" do
+    assert_raise Mix.Error, "--token requires --grisp-io-linking", fn ->
+      %{base_config() | token: "token"}
+      |> Validator.validate!()
+    end
+  end
+
+  test "validator rejects cookie without epmd" do
+    assert_raise Mix.Error, "--cookie requires --epmd", fn ->
+      %{base_config() | cookie: "grisp"}
+      |> Validator.validate!()
+    end
+  end
+
+  test "validator accepts a valid config" do
+    config =
+      Configure.defaults()
+      |> Map.merge(%{
+        name: "demo",
+        network: true,
+        wifi: true,
+        ssid: "mywifi",
+        psk: "secret",
+        grisp_io: true,
+        grisp_io_linking: true,
+        token: "token",
+        epmd: true,
+        cookie: "grisp"
+      })
+      |> Validator.validate!()
+
+    assert config.name == "demo"
+    assert config.grisp_io
+    assert config.cookie == "grisp"
+  end
+
+  test "validator allows blank optional strings after normalization" do
+    config =
+      base_config()
+      |> Map.merge(%{
+        token: "   ",
+        cookie: "  ",
+        destination: "  "
+      })
+      |> Validator.validate!()
+
+    assert config.token == nil
+    assert config.cookie == nil
+    assert config.destination == nil
+  end
+end

--- a/test/mix_grisp/configure/validator_test.exs
+++ b/test/mix_grisp/configure/validator_test.exs
@@ -15,7 +15,7 @@ defmodule MixGrisp.Configure.ValidatorTest do
              otp_version: "27",
              destination: nil,
              network: false,
-             wifi: false,
+             network_type: nil,
              ssid: nil,
              psk: nil,
              grisp_io: false,
@@ -37,6 +37,7 @@ defmodule MixGrisp.Configure.ValidatorTest do
 
     assert config.name == "demo"
     assert config.network
+    assert config.network_type == nil
     assert config.ssid == nil
     assert config.destination == nil
     assert config.otp_version == "27"
@@ -46,12 +47,14 @@ defmodule MixGrisp.Configure.ValidatorTest do
     config =
       Configure.merge_cli(
         name: "  demo  ",
+        network_type: "  wifi  ",
         ssid: "   ",
         token: "  ",
         destination: "  /tmp/grisp  "
       )
 
     assert config.name == "demo"
+    assert config.network_type == "wifi"
     assert config.ssid == nil
     assert config.token == nil
     assert config.destination == "/tmp/grisp"
@@ -71,22 +74,29 @@ defmodule MixGrisp.Configure.ValidatorTest do
     end
   end
 
-  test "validator rejects wifi without network" do
-    assert_raise Mix.Error, "--wifi requires --network", fn ->
-      %{base_config() | wifi: true}
+  test "validator rejects invalid network type" do
+    assert_raise Mix.Error, "--network-type must be either ethernet or wifi", fn ->
+      %{base_config() | network: true, network_type: "bluetooth"}
+      |> Validator.validate!()
+    end
+  end
+
+  test "validator rejects network type without network" do
+    assert_raise Mix.Error, "--network-type requires --network", fn ->
+      %{base_config() | network_type: "wifi"}
       |> Validator.validate!()
     end
   end
 
   test "validator rejects ssid without wifi" do
-    assert_raise Mix.Error, "--ssid requires --wifi", fn ->
+    assert_raise Mix.Error, "--ssid requires --network-type wifi", fn ->
       %{base_config() | ssid: "mywifi"}
       |> Validator.validate!()
     end
   end
 
   test "validator rejects psk without wifi" do
-    assert_raise Mix.Error, "--psk requires --wifi", fn ->
+    assert_raise Mix.Error, "--psk requires --network-type wifi", fn ->
       %{base_config() | psk: "secret"}
       |> Validator.validate!()
     end
@@ -126,7 +136,7 @@ defmodule MixGrisp.Configure.ValidatorTest do
       |> Map.merge(%{
         name: "demo",
         network: true,
-        wifi: true,
+        network_type: "wifi",
         ssid: "mywifi",
         psk: "secret",
         grisp_io: true,
@@ -146,6 +156,8 @@ defmodule MixGrisp.Configure.ValidatorTest do
     config =
       base_config()
       |> Map.merge(%{
+        network: true,
+        network_type: "ethernet",
         token: "   ",
         cookie: "  ",
         destination: "  "


### PR DESCRIPTION
Adds mix grisp.configure with a focus on GRiSP.io setup.

  Includes:
  - interactive and non-interactive configuration flow
  - GRiSP.io config/config.exs patching
  - deploy file generation for network setup
  - epmd support with grisp.ini.mustache flags
  - conservative mix.exs patching with manual fallback steps
  - documentation for the current CLI flow
  - a minimal zizmor workflow for code scanning